### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/charts/limesurvey/tests/deployment_test.yaml
+++ b/charts/limesurvey/tests/deployment_test.yaml
@@ -113,7 +113,7 @@ tests:
     set:
       ### Helm values:
       image:
-        registry: gchr.io
+        registry: ghcr.io
         tag: debian-ramesses-the-third
       persistence:
         enabled: true
@@ -122,7 +122,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: gchr.io/martialblog/limesurvey:debian-ramesses-the-third
+          value: ghcr.io/martialblog/limesurvey:debian-ramesses-the-third
       - equal:
           path: spec.template.spec.containers[0].volumeMounts[0].name
           value: storage


### PR DESCRIPTION
Hi `AlexanderBabel/helm-charts`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used - In some cases it's only a matter of wrongly tagged container images)
Please verify the changes made with this PR and check your documentation for similar typos.